### PR TITLE
Added shape field for microorganism

### DIFF
--- a/src/senaite/microorganism/behaviors/microorganism.py
+++ b/src/senaite/microorganism/behaviors/microorganism.py
@@ -34,6 +34,13 @@ class IMicroorganismBehavior(model.Schema):
     gram_stain = schema.Choice(
         title=_(u"Gram stain"),
         vocabulary="senaite.microorganism.vocabularies.gram_stains",
+        required=False,
+    )
+
+    shape = schema.Choice(
+        title=_(u"Shape"),
+        vocabulary="senaite.microorganism.vocabularies.shapes",
+        required=False,
     )
 
     glass = schema.Bool(
@@ -75,6 +82,14 @@ class Microorganism(object):
         self.context.gram_stain = value
 
     gram_stain = property(_get_gram_stain, _set_gram_stain)
+
+    def _get_shape(self):
+        return getattr(self.context, "shape")
+
+    def _set_shape(self, value):
+        self.context.shape = value
+
+    shape = property(_get_shape, _set_shape)
 
     def _get_glass(self):
         return getattr(self.context, "glass", False)

--- a/src/senaite/microorganism/browser/content/microorganismfolder.py
+++ b/src/senaite/microorganism/browser/content/microorganismfolder.py
@@ -28,6 +28,7 @@ from plone.memoize import view
 from senaite.app.listing import ListingView
 from senaite.microorganism import messageFactory as _
 from senaite.microorganism.config import GRAM_STAIN_OPTIONS
+from senaite.microorganism.config import SHAPE_OPTIONS
 
 
 class MicroorganismFolderView(ListingView):
@@ -60,6 +61,9 @@ class MicroorganismFolderView(ListingView):
             }),
             ("gram_stain", {
                 "title": _("Gram stain")
+            }),
+            ("shape", {
+                "title": _("Shape"),
             }),
             ("glass", {
                 "title": _("GLASS"),
@@ -121,6 +125,7 @@ class MicroorganismFolderView(ListingView):
 
         obj = api.get_object(obj)
         item["gram_stain"] = self.get_gram_stain_title(obj.gram_stain)
+        item["shape"] = self.get_shape_title(obj.shape)
         item["glass"] = obj.glass
         item["mro"] = obj.multi_resistant
         item["mro_phenotype"] = obj.mro_phenotype
@@ -140,3 +145,9 @@ class MicroorganismFolderView(ListingView):
         """Returns the title of the gram satin value passed-in
         """
         return dict(GRAM_STAIN_OPTIONS).get(gram_stain_value, "")
+
+    @view.memoize
+    def get_shape_title(self, shape_value):
+        """Returns the title of the shape value passed-in
+        """
+        return dict(SHAPE_OPTIONS).get(shape_value, "")

--- a/src/senaite/microorganism/config.py
+++ b/src/senaite/microorganism/config.py
@@ -23,7 +23,34 @@ from senaite.microorganism import messageFactory as _
 # Gram stain options
 # List of (value, title) tuples
 GRAM_STAIN_OPTIONS = [
-    ("undef", _("Undefined")),
     ("gram+", _("Gram-positive")),
     ("gram-", _("Gram-negative")),
+]
+
+# Microorganism shape options
+# List of (value, title) tuples
+# Three basic shapes: coccus, rod or bacillus, and spiral.
+SHAPE_OPTIONS = [
+    # The cocci are spherical or oval bacteria
+    ("coccus", _("Coccus")),
+    # Cocci have one of several distinct arrangements based on their planes of
+    # division: diplococci, staphylococci, streptococci, sarcina, tetrad
+    ("coccus.diplococci", _("Diplococci")),
+    ("coccus.staphylococci", _("Staphylococci")),
+    ("coccus.streptococci", _("Streptococci")),
+    ("coccus.sarcina", _("Sarcina")),
+    ("coccus.tetrad", _("Tetrad")),
+
+    # Bacilli (or rod) are rod-shaped bacteria
+    ("rod", _("Rod")),
+    # Bacilli all divide in one plane producing a bacillus, streptobacillus, or
+    # coccobacillus arrangement
+    ("rod.bacillus", _("Bacillus")),
+    ("rod.streptobacilli", _("Streptobacilli")),
+    ("rod.coccobacilli", _("Coccobacilli")),
+
+    # Spirals come in one of three forms, a vibrio, a spirillum, or a spirochete
+    ("spiral", _("Spiral")),
+    ("spiral.vibrio", _("Vibrio")),
+    ("spiral.spirillum", _("Spirillum"))
 ]

--- a/src/senaite/microorganism/configure.zcml
+++ b/src/senaite/microorganism/configure.zcml
@@ -21,6 +21,9 @@
   <utility
       component="senaite.microorganism.vocabularies.GramStainsVocabularyFactory"
       name="senaite.microorganism.vocabularies.gram_stains" />
+  <utility
+      component="senaite.microorganism.vocabularies.ShapesVocabularyFactory"
+      name="senaite.microorganism.vocabularies.shapes" />
 
   <!-- Default profile -->
   <genericsetup:registerProfile

--- a/src/senaite/microorganism/vocabularies.py
+++ b/src/senaite/microorganism/vocabularies.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from senaite.microorganism.config import GRAM_STAIN_OPTIONS
+from senaite.microorganism.config import SHAPE_OPTIONS
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
@@ -38,3 +39,18 @@ class GramStainsVocabulary(object):
 
 
 GramStainsVocabularyFactory = GramStainsVocabulary()
+
+
+@implementer(IVocabularyFactory)
+class ShapesVocabulary(object):
+    """Vocabulary of pre-defined Shapes
+    """
+
+    def __call__(self, context):
+        """Returns a SimpleVocabulary of microorganism shapes
+        """
+        items = map(lambda g: SimpleTerm(g[0], title=g[1]), SHAPE_OPTIONS)
+        return SimpleVocabulary(items)
+
+
+ShapesVocabularyFactory = ShapesVocabulary()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests adds the field "Shape" to Microorganism portal type, as a selection list with pre-populated with the most common cellular morphologies and arrangements of bacteria.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html