### PR TITLE
Fix error in microorganisms listing when microorganism w/o category set

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Steps to reproduce
+
+## Current behavior
+
+## Expected behavior
+
+## Screenshot (optional)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Description of the issue/feature this PR addresses
+
+Linked issue: https://github.com/senaite/senaite.microorganism/issues/
+
+## Current behavior before PR
+
+## Desired behavior after PR is merged
+
+--
+I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
+and [Plone's Python styleguide][2] standards.
+
+[1]: https://www.python.org/dev/peps/pep-0008
+[2]: https://docs.plone.org/develop/styleguide/python.html

--- a/src/senaite/microorganism/browser/content/microorganismfolder.py
+++ b/src/senaite/microorganism/browser/content/microorganismfolder.py
@@ -167,7 +167,8 @@ class MicroorganismFolderView(ListingView):
         category = microorganism.category
         if category:
             category = category[0]
-        return self.get_obj_title(category, default=default)
+            return self.get_obj_title(category, default=default)
+        return default
 
     @view.memoize
     def get_obj_title(self, obj_uid, default=None):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an error in microorganisms listing when a microorganism does not have any category set.

## Current behavior before PR

```
2022-02-04 21:34:08,642 ERROR   [Zope.SiteErrorLog:252][waitress-0] 1643974448.640.606499031343 http://localhost:9090/senaite/bika_setup/microorganisms/view/folderitems
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 223, in __call__
  Module senaite.app.listing.ajax, line 109, in handle_subpath
  Module senaite.core.decorators, line 20, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 432, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 313, in get_folderitems
  Module senaite.app.listing.view, line 937, in folderitems
  Module senaite.microorganism.browser.content.microorganismfolder, line 131, in folderitem
  Module senaite.microorganism.browser.content.microorganismfolder, line 153, in categorize
  Module senaite.microorganism.browser.content.microorganismfolder, line 170, in get_category_title
  Module plone.memoize.view, line 58, in memogetter
TypeError: unhashable type: 'list'
```

## Desired behavior after PR is merged

No traceback. Microorganisms are  listed correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
