### PR TITLE
Do not allow microorganisms with same title

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #7 Do not allow microorganisms with same title
 - #6 Remove IMicroorganismBehavior and make Microorganism folderish
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Merge https://github.com/senaite/senaite.microorganism/pull/6 first**

This Pull Request guarantees uniqueness of microorganism names

Linked issue: https://github.com/senaite/senaite.microorganism/issues/

## Current behavior before PR

User can create (or edit) microorganisms with existing names

## Desired behavior after PR is merged

User is prompted to change the title of the microorganism if already exists on edit/creation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
